### PR TITLE
Use abs path to mv

### DIFF
--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -2,7 +2,7 @@ function __z -d "Jump to a recent directory."
   set -l option
   set -l arg
   set -l typ ''
-  set -g z_path (dirname (status -f))
+  set -g z_path (command dirname (status -f))
   set -l target
 
   getopts $argv | while read -l 1 2
@@ -50,7 +50,7 @@ function __z -d "Jump to a recent directory."
     if test 1 -eq (printf "%s" $arg | grep -c "^\/")
       set target $arg
     else
-      set target (awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA") 
+      set target (command awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA") 
     end
 
     if test "$option" = "list"

--- a/functions/__z_add.fish
+++ b/functions/__z_add.fish
@@ -1,5 +1,5 @@
 function __z_add -d "Add PATH to .z file"
-  set -l path (dirname (status -f))
+  set -l path (command dirname (status -f))
 
   for i in $Z_EXCLUDE
     if contains -- $PWD $i
@@ -10,8 +10,8 @@ function __z_add -d "Add PATH to .z file"
   set -l tmpfile (mktemp $Z_DATA.XXXXXX)
 
   if test -f $tmpfile
-    awk -v path="$PWD" -v now=(date +%s) -F "|" -f $path/zadd.awk $Z_DATA ^ /dev/null > $tmpfile
-    mv -f $tmpfile $Z_DATA
+    command awk -v path="$PWD" -v now=(date +%s) -F "|" -f $path/zadd.awk $Z_DATA ^ /dev/null > $tmpfile
+    command mv -f $tmpfile $Z_DATA
   end
 
   __z_complete

--- a/functions/__zo.fish
+++ b/functions/__zo.fish
@@ -2,7 +2,7 @@ function __zo -d "Jump to a recent directory."
   set -l option
   set -l arg
   set -l typ ''
-  set -g z_path (dirname (status -f))
+  set -g z_path (command dirname (status -f))
   set -l target
 
   getopts $argv | while read -l 1 2
@@ -26,7 +26,7 @@ function __zo -d "Jump to a recent directory."
   if test 1 -eq (printf "%s" $arg | grep -c "^\/")
     set target $arg
   else
-    set target (awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
+    set target (command awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
   end
 
   if test -z "$target"


### PR DESCRIPTION
Users could have mv aliased as mv --verbose
It is irritating to see the mv verbose output whenever z adds a directory.