### PR TITLE
Relocated default data dir to XDG spec location

### DIFF
--- a/conf.d/z.fish
+++ b/conf.d/z.fish
@@ -1,8 +1,16 @@
 if test -z "$Z_DATA"
-  set -U Z_DATA "$HOME/.z"
+  if test -z "$XDG_DATA_HOME"
+    set -U Z_DATA_DIR "$HOME/.local/share/z"
+  else 
+    set -U Z_DATA_DIR "$XDG_DATA_HOME/z"
+  end
+  set -U Z_DATA "$Z_DATA_DIR/data"
 end
 
-if test ! -f "$Z_DATA"
+if test ! -e "$Z_DATA"
+  if test ! -e "$Z_DATA_DIR"
+    mkdir -p "$Z_DATA_DIR"  
+  end
   touch "$Z_DATA"
 end
 

--- a/conf.d/z.fish
+++ b/conf.d/z.fish
@@ -9,7 +9,7 @@ end
 
 if test ! -e "$Z_DATA"
   if test ! -e "$Z_DATA_DIR"
-    mkdir -p "$Z_DATA_DIR"  
+    mkdir -p -m 700 "$Z_DATA_DIR"  
   end
   touch "$Z_DATA"
 end


### PR DESCRIPTION
`z` currently puts it's data in `$HOME` by default. This contributes to the dot file clutter in a user's home folder. The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/index.html)—which `fish` itself follows—specifies folders for configuration, cache, and data files. By following this spec apps/utilities can store files in sensible “standard” locations and avoid cluttering up `$HOME` with dot files.

If `$Z_DATA` doesn't exist, this change to `z.fish` will set it to the XDG spec location, otherwise the value stays the same. So this should solve the issue going forward, while not breaking `z` for existing users who have the data file in `$HOME`.