### PR TITLE
Change --clean to remove folders no longer valid (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ curl -L git.io/v6kNP >> ~/.config/fish/config.fish
 z [-c --clean]       Cleans out Z_DATA
 z [-e --echo] foo    Prints best match, no cd
 z [-l --list] foo    List matches, no cd
+z [-p --purge]       Purges Z_DATA
 z [-r --rank] foo    Searches by rank, cd
 z [-t --recent] foo  Searches by recency, cd
 z [ -h --help]       Print this help

--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -8,8 +8,12 @@ function __z -d "Jump to a recent directory."
   getopts $argv | while read -l 1 2
     switch $1
       case c clean
-        echo > $Z_DATA
+        __z_clean
         printf "%s cleaned!" $Z_DATA
+        return 0
+      case p purge
+        echo > $Z_DATA
+        printf "%s purged!" $Z_DATA
         return 0
       case e echo
         set option "ech"
@@ -35,6 +39,7 @@ function __z -d "Jump to a recent directory."
         printf "         -c --clean    Cleans out $Z_DATA\n"
         printf "         -e --echo     Prints best match, no cd\n"
         printf "         -l --list     List matches, no cd\n"
+        printf "         -p --purge    Purges $Z_DATA\n"
         printf "         -r --rank     Search by rank, cd\n"
         printf "         -t --recent   Search by recency, cd\n"
         printf "         -h --help     Print this help\n\n"
@@ -50,7 +55,7 @@ function __z -d "Jump to a recent directory."
     if test 1 -eq (printf "%s" $arg | grep -c "^\/")
       set target $arg
     else
-      set target (command awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA") 
+      set target (command awk -v t=(date +%s) -v option="$option" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
     end
 
     if test "$option" = "list"

--- a/functions/__z_clean.fish
+++ b/functions/__z_clean.fish
@@ -1,0 +1,11 @@
+function __z_clean -d "Clean up .z file to remove paths no longer valid"
+  set -l path (command dirname (status -f))
+  set -l tmpfile (mktemp $Z_DATA.XXXXXX)
+
+  if test -f $tmpfile
+    command awk -F "|" -f $path/zclean.awk $Z_DATA > $tmpfile
+    command mv -f $tmpfile $Z_DATA
+  end
+
+  __z_complete
+end

--- a/functions/zclean.awk
+++ b/functions/zclean.awk
@@ -1,0 +1,1 @@
+system("test -d \"" $1 "\"") == 0 { print $0 }

--- a/test/z.fish
+++ b/test/z.fish
@@ -34,8 +34,15 @@ test "! has kid"
   1 -eq (grep -q kid $Z_DATA; echo $status)
 end
 
+test "z --purge"
+  -z (z --purge > /dev/null; cat $Z_DATA)
+end
+
 test "z --clean"
-  -z (z --clean > /dev/null; cat $Z_DATA)
+  1 -eq (echo '$pth/invalid_path|1|1501234567' >> $Z_DATA;
+         z --clean > /dev/null;
+         grep -q invalid_path $Z_DATA;
+         echo $status)
 end
 
 test "z -e foo"


### PR DESCRIPTION
Original `z --clean` will delete all entries in the $Z_DATA.

Now we use `z --clean` to only remove folders that no longer valid,
and use `z --purge` to delete all entries.