### PR TITLE
Fix list printing to stderr. Fixes #47

### DIFF
--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -61,7 +61,7 @@ function __z -d "Jump to a recent directory."
     if test 1 -eq (printf "%s" $arg | grep -c "^\/")
       set target $arg
     else
-      set target (command awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
+      set target (command awk -v t=(date +%s) -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
     end
 
     if test "$status" -gt 0

--- a/functions/__z.fish
+++ b/functions/__z.fish
@@ -53,29 +53,30 @@ function __z -d "Jump to a recent directory."
     end
   end
 
-  if test 1 -eq (printf "%s" $arg | grep -c "^\/")
-    set target $arg
-  else
-    set target (command awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
-  end
-
   if test "$list" = "list"
-    echo "$target" | tr ";" "\n" | sort -nr
-    return 0
-  end
+    # Handle list separately as it can print common path information to stderr
+    # which can not be captured from a subcommand.
+    command awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA"
+  else
+    if test 1 -eq (printf "%s" $arg | grep -c "^\/")
+      set target $arg
+    else
+      set target (command awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$arg" -F "|" -f $z_path/z.awk "$Z_DATA")
+    end
 
-  if test "$status" -gt 0
-    return
-  end
+    if test "$status" -gt 0
+      return
+    end
 
-  if test -z "$target"
-    printf "'%s' did not match any results" "$arg"
-    return 1
-  end
+    if test -z "$target"
+      printf "'%s' did not match any results" "$arg"
+      return 1
+    end
 
-  if contains -- ech $option
-    printf "%s\n" "$target"
-  else if not contains -- list $option
-    pushd "$target"
+    if test "$option" = "ech"
+      printf "%s\n" "$target"
+    else
+      pushd "$target"
+    end
   end
 end

--- a/functions/z.awk
+++ b/functions/z.awk
@@ -9,7 +9,7 @@ function frecent(rank, time) {
 function output(matches, best_match, common) {
     # list or return the desired directory
     if( list ) {
-        cmd = "sort -n >&2"
+        cmd = "sort -n"
         for( x in matches ) {
             if( matches[x] ) {
                 printf "%-10s %s\n", matches[x], x | cmd

--- a/test/z.fish
+++ b/test/z.fish
@@ -72,3 +72,11 @@ end
 test "z kid"
   "'kid' did not match any results1" = (z kid; and echo $PWD $status; or echo $status)
 end
+
+test "z --list foo"
+  $pth/foo = (z --list foo ^/dev/null | awk '{ print $2} ')
+end
+
+test "list common path on stderr"
+  "common:    $pth/foo" = (z --list foo 2>&1 >/dev/null | grep common:)
+end


### PR DESCRIPTION
- `--list` no longer prints to `stderr`
- `--list` common path still prints to `stderr`
- reworked logic for how `--list` is called, don't do it in a subcommand as we need `stderr`
- added two tests 