### PR TITLE
Use traditional redirection for stderr

### DIFF
--- a/functions/__z_add.fish
+++ b/functions/__z_add.fish
@@ -10,7 +10,7 @@ function __z_add -d "Add PATH to .z file"
   set -l tmpfile (mktemp $Z_DATA.XXXXXX)
 
   if test -f $tmpfile
-    command awk -v path="$PWD" -v now=(date +%s) -F "|" -f $path/zadd.awk $Z_DATA ^ /dev/null > $tmpfile
+    command awk -v path="$PWD" -v now=(date +%s) -F "|" -f $path/zadd.awk $Z_DATA 2>/dev/null >$tmpfile
     if test ! -z "$Z_OWNER"
       chown $Z_OWNER:(id -ng $Z_OWNER) "$tempfile"
     end


### PR DESCRIPTION
The caret (`^`) has been removed as a redirector for `stderr` in Fish v3, see https://github.com/fish-shell/fish-shell/issues/4394 for details.